### PR TITLE
Use setup.cfg to house project metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,31 @@
+[metadata]
+name = case_gnu_time
+version = attr: case_gnu_time.__version__
+author = Alex Nelson
+author_email = alexander.nelson@nist.gov
+description = A mapping of GNU Time to CASE
+license_files = LICENSE
+#TODO - PyPI will need a differently-written README.
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/casework/CASE-Implementation-GNU-Time
+classifiers =
+    Development Status :: 4 - Beta
+    License :: Public Domain
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+
+[options]
+install_requires =
+    # TODO - This constraint on pyparsing can be removed when rdflib Issue #1190 is resolved.
+    # https://github.com/RDFLib/rdflib/issues/1190
+    pyparsing < 3.0.0
+    python-dateutil
+    rdflib
+    requests
+packages = find:
+python_requires = >=3.6
+
+[options.entry_points]
+console_scripts =
+    case_gnu_time = case_gnu_time:main

--- a/setup.py
+++ b/setup.py
@@ -13,41 +13,5 @@
 
 import setuptools
 
-#TODO - PyPI will need a differently-written README.
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
-setup_kwargs = {
-  "name": "case_gnu_time",
-  "version": "attr: case_gnu_time.__version__",
-  "author": "Alex Nelson",
-  "author_email": "alexander.nelson@nist.gov",
-  "description": "A mapping of GNU Time to CASE",
-  "long_description": long_description,
-  "long_description_content_type": "text/markdown",
-  "url": "https://github.com/casework/CASE-Implementation-GNU-Time",
-  "packages": setuptools.find_packages(),
-  "classifiers": [
-    "Development Status :: 4 - Beta",
-    "License :: Public Domain",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3"
-  ],
-  "python_requires": ">=3.6",
-  "install_requires": [
-    # TODO This constraint on pyparsing can be removed when rdflib Issue #1190 is resolved.
-    # https://github.com/RDFLib/rdflib/issues/1190
-    "pyparsing < 3.0.0",
-    "python-dateutil",
-    "rdflib",
-    "requests"
-  ],
-  "entry_points": {
-    "console_scripts": [
-      "case_gnu_time=case_gnu_time:main"
-    ]
-  }
-}
-
 if __name__ == "__main__":
-    setuptools.setup(**setup_kwargs)
+    setuptools.setup()

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -37,6 +37,7 @@ all: \
   $(top_srcdir)/.git_submodule_init.done.log \
   $(top_srcdir)/case_gnu_time/__init__.py \
   $(top_srcdir)/case_gnu_time/local_uuid.py \
+  $(top_srcdir)/setup.cfg \
   $(top_srcdir)/setup.py \
   requirements.txt
 	rm -rf venv
@@ -57,6 +58,7 @@ all: \
 
 .venv_minimal.done.log: \
   $(top_srcdir)/.git_submodule_init.done.log \
+  $(top_srcdir)/setup.cfg \
   $(top_srcdir)/setup.py \
   requirements.txt
 	rm -rf venv_minimal


### PR DESCRIPTION
The built distribution file was observed to have a strange string in
place of where a version string was expected.  The issue has been
reported to the setuptools project:
https://github.com/pypa/setuptools/issues/2492

The installation file is named as expected when using setup.cfg.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>