### PR TITLE
Upgrade setuptools in virtual environments

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -47,7 +47,8 @@ all: \
 	source venv/bin/activate ; \
 	  pip install \
 	    --upgrade \
-	    pip
+	    pip \
+	    setuptools
 	source venv/bin/activate ; \
 	  cd $(top_srcdir) ; \
 	    python3 setup.py install
@@ -68,7 +69,8 @@ all: \
 	source venv_minimal/bin/activate ; \
 	  pip install \
 	    --upgrade \
-	    pip
+	    pip \
+	    setuptools
 	source venv_minimal/bin/activate ; \
 	  pip install \
 	    -r requirements.txt


### PR DESCRIPTION
An error state popped up in an Ubuntu 18.04 environment.  Setuptools was
failing to install dependency packages from setup.cfg, causing
'import dateutil' in case_gnu_time/__init__.py to fail with an import
error.

Setuptools in that environment's system-wide deployment is version
45.2.0, but when provided by the up-to-date virtualenv package, it is
44.0.0 in a fresh virtual environment.  Upgrading setuptools in the
virtual environment setup installs version 51.1.1.  Version 51.1.1
installs dependent packages in the expected order.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>