### PR TITLE
Localize pytest call, and recurse with 'make check'

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -31,6 +31,10 @@ all: \
   all-from_pip \
   all-gtime_log \
   all-gtime_and_done_log \
+  check-as_import \
+  check-from_pip \
+  check-gtime_log \
+  check-gtime_and_done_log \
   download
 
 .venv.done.log: \
@@ -101,15 +105,35 @@ all-gtime_and_done_log: \
 	  --directory gtime_and_done_log
 
 # Dependencies are listed here in desired execution-progression order.
-# Each subdirectory may have a 'make check' to call pytest locally, so 'make check' here does not recursively call 'make check' in the directories below.  This is why there are 'all-' recursion targets.
 check: \
-  all-gtime_log \
-  all-gtime_and_done_log \
-  all-from_pip \
+  check-gtime_log \
+  check-gtime_and_done_log \
+  check-from_pip \
+  check-as_import
+
+check-as_import: \
   all-as_import
-	source $(srcdir)/venv/bin/activate \
-	  && pytest \
-	    --log-level=DEBUG
+	$(MAKE) \
+	  --directory as_import \
+	  check
+
+check-from_pip: \
+  all-from_pip
+	$(MAKE) \
+	  --directory from_pip \
+	  check
+
+check-gtime_log: \
+  all-gtime_log
+	$(MAKE) \
+	  --directory gtime_log \
+	  check
+
+check-gtime_and_done_log: \
+  all-gtime_and_done_log
+	$(MAKE) \
+	  --directory gtime_and_done_log \
+	  check
 
 clean:
 	@$(MAKE) \

--- a/tests/as_import/Makefile
+++ b/tests/as_import/Makefile
@@ -45,7 +45,8 @@ check: \
 	@test ! -s undefined_vocabulary.txt \
 	  || (echo "ERROR:tests/as_import/Makefile:The output in process.json has undefined CASE or UCO terms.  The first few are:" >&2 && head undefined_vocabulary.txt >&2 && exit 1)
 	source $(tests_srcdir)/venv/bin/activate \
-	  && pytest
+	  && pytest \
+	    --log-level=DEBUG
 
 clean:
 	@rm -f \


### PR DESCRIPTION
There was an error in recursively reviewing the localized vocabulary
files in the test directories.  Setting up a `/tests`-wide pytest call
accidentally skipped descending and reviewing the local vocabulary
files.

This patch moves the pytest call to its current one test case.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>