### PR TITLE
Add 'wheel' to test virtual environment setup

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -51,7 +51,8 @@ all: \
 	  && pip install \
 	    --upgrade \
 	    pip \
-	    setuptools
+	    setuptools \
+	    wheel
 	source venv/bin/activate \
 	  && cd $(top_srcdir)/dependencies/CASE-Utilities-Python \
 	    && pip install \
@@ -80,7 +81,8 @@ all: \
 	  && pip install \
 	    --upgrade \
 	    pip \
-	    setuptools
+	    setuptools \
+	    wheel
 	source venv_minimal/bin/activate \
 	  && cd $(top_srcdir)/dependencies/CASE-Utilities-Python \
 	    && pip install \


### PR DESCRIPTION
This quiets the following message:

> Using legacy 'setup.py install' for case-utils, since package 'wheel'
> is not installed.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>