### PR TITLE
Schedule recurring CI cron job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
+  schedule:
+    - cron: '15 5 * * TUE'
 
 jobs:
   build:


### PR DESCRIPTION
This will have the benefit of catching when an upstream updated package introduces a compatibility issue.

This cron job should trigger to leave notices for maintainers on the US East Coast to see on their Tuesday mornings.