### PR TITLE
Bump Python testing floor in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     case_utils >= 0.9.0, < 0.10.0
     python-dateutil
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This patch should have been incorporated in #31.